### PR TITLE
Add .catch to failure/success chaining possibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (master)
 ### Added
+- Add `catch` to `Failure` and `Success`. It acts as an inverted `then`.
 - Yields result type on blocks (`then`, `on_success` and `on_failure`)
 - Add type check on `Result#on_success` and `Result#on_failure` hooks.
 - Add method `Base#Try`. It wraps exceptions in Failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (master)
 ### Added
-- Add `catch` to `Failure` and `Success`. It acts as an inverted `then`.
+- Add `catch` to `Failure` and `Success`. It acts as an inverted `then` and has a `or` alias.
 - Add support to custom `data` property to be passed when calling `Base#Check`.
 - Add support to multiple type checks on `Result#on_success` and `Result#on_failure` hooks.
 - Yields result type on blocks (`then`, `on_success` and `on_failure`).

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -59,6 +59,31 @@ module FService
         raise Result::Error, 'Failure objects do not have value'
       end
 
+      # Returns its value to the given block.
+      # Use this to chain multiple service calls (since all services return Results).
+      #
+      #
+      # @example
+      #   class UsersController < BaseController
+      #     def create
+      #       result = User::Create.(user_params)
+      #                            .then { |user| User::SendWelcomeEmail.(user: user) }
+      #                            .catch { |error| Logger::Notificate.(error: error) }
+      #
+      #       if result.successful?
+      #         json_success(result.value)
+      #       else
+      #         json_error(result.error)
+      #       end
+      #     end
+      #   end
+      #
+      # @yieldparam error pass {#error} to a block
+      # @yieldparam type pass {#type} to a block
+      def catch
+        yield(*to_ary)
+      end
+
       # Returns itself to the given block.
       # Use this to chain multiple service calls (since all services return Results).
       # It will short circuit your service call chain.

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -61,32 +61,7 @@ module FService
 
       # Returns the current error to the given block.
       # Use this to chain multiple service calls (since all services return Results).
-      #
-      #
-      # @example
-      #   class UsersController < BaseController
-      #     def create
-      #       result = User::Create.(user_params)
-      #                            .then { |user| User::SendWelcomeEmail.(user: user) }
-      #                            .catch { |error| Logger::Notificate.(error: error) }
-      #
-      #       if result.successful?
-      #         json_success(result.value)
-      #       else
-      #         json_error(result.error)
-      #       end
-      #     end
-      #   end
-      #
-      # @yieldparam error pass {#error} to a block
-      # @yieldparam type pass {#type} to a block
-      def catch
-        yield(*to_ary)
-      end
-
-      # Returns itself to the given block.
-      # Use this to chain multiple service calls (since all services return Results).
-      # It will short circuit your service call chain.
+      # It works just like the `.then` method, but only runs if service is a Failure.
       #
       #
       # @example
@@ -101,6 +76,32 @@ module FService
       #
       #     private
       #     # some code
+      #   end
+      #
+      # @yieldparam error pass {#error} to a block
+      # @yieldparam type pass {#type} to a block
+      def catch
+        yield(*to_ary)
+      end
+
+      # Returns itself to the given block.
+      # Use this to chain multiple service calls (since all services return Results).
+      # It will short circuit your service call chain.
+      #
+      #
+      # @example
+      #   class UsersController < BaseController
+      #     def create
+      #       result = User::Create.(user_params) # if this fails the following calls won't run
+      #                            .then { |user| User::SendWelcomeEmail.(user: user) }
+      #                            .then { |user| User::Login.(user: user) }
+      #
+      #       if result.successful?
+      #         json_success(result.value)
+      #       else
+      #         json_error(result.error)
+      #       end
+      #     end
       #   end
       #
       # @return [self]

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -61,7 +61,7 @@ module FService
 
       # Returns the current error to the given block.
       # Use this to chain multiple service calls (since all services return Results).
-      # It works just like the `.then` method, but only runs if service is a Failure.
+      # It works just like the `.then` method, but only runs if the result is a Failure.
       #
       #
       # @example

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -59,7 +59,7 @@ module FService
         raise Result::Error, 'Failure objects do not have value'
       end
 
-      # Returns its value to the given block.
+      # Returns the current error to the given block.
       # Use this to chain multiple service calls (since all services return Results).
       #
       #

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -84,6 +84,8 @@ module FService
         yield(*to_ary)
       end
 
+      alias or catch
+
       # Returns itself to the given block.
       # Use this to chain multiple service calls (since all services return Results).
       # It will short circuit your service call chain.

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -85,22 +85,22 @@ module FService
       end
 
       # Returns itself to the given block.
-      # Use this to chain multiple service calls (since all services return Results).
-      # It will short circuit your service call chain if only consists of catches.
+      # Use this to chain multiple actions or service calls (only valid when they return a Result).
+      # It works just like the `.then` method, but only runs if service is a Failure.
       #
       #
       # @example
-      #   class UsersController < BaseController
-      #     def create
-      #       result = User::Create.(user_params) # if this success the following call won't run
-      #                            .catch { |error| Logger::Notify.(error: user) }
+      #   class UpdateUserOnExternalService
+      #     attribute :user_params
       #
-      #       if result.successful?
-      #         json_success(result.value)
-      #       else
-      #         json_error(result.error)
-      #       end
+      #     def run
+      #       check_api_status
+      #         .then { update_user }
+      #         .catch { create_update_worker }
       #     end
+      #
+      #     private
+      #     # some code
       #   end
       #
       # @return [self]

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -84,6 +84,30 @@ module FService
         yield(*to_ary)
       end
 
+      # Returns itself to the given block.
+      # Use this to chain multiple service calls (since all services return Results).
+      # It will short circuit your service call chain if only consists of catches.
+      #
+      #
+      # @example
+      #   class UsersController < BaseController
+      #     def create
+      #       result = User::Create.(user_params) # if this success the following call won't run
+      #                            .catch { |error| Logger::Notify.(error: user) }
+      #
+      #       if result.successful?
+      #         json_success(result.value)
+      #       else
+      #         json_error(result.error)
+      #       end
+      #     end
+      #   end
+      #
+      # @return [self]
+      def catch
+        self
+      end
+
       # Outputs a string representation of the object
       #
       #

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -108,6 +108,8 @@ module FService
         self
       end
 
+      alias or catch
+
       # Outputs a string representation of the object
       #
       #

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe FService::Result::Failure do
         expect(chain.error).to eq('This... Fails!')
       end
     end
+
+    context 'when chaining results with a catch block' do
+      subject(:chain) do
+        FService::Result::Success.new('This...')
+                                 .then { |value| described_class.new(value + ' Fails!') }
+                                 .catch { |error| described_class.new(error + ' Again!') }
+                                 .then { |_value| raise "This won't ever run!" }
+      end
+
+      it { expect(chain).to be_failed }
+
+      it 'executes the catch block ' do
+        expect(chain.error).to eq('This... Fails! Again!')
+      end
+    end
   end
 
   describe '#on_failure' do

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe FService::Result::Failure do
         expect(chain.error).to eq('This... Fails! Again!')
       end
     end
+
+    context 'when chaining results with a catch block using the `or` alias' do
+      subject(:chain) do
+        FService::Result::Success.new('This...')
+                                 .then { |value| described_class.new(value + ' Fails!') }
+                                 .or { |error| described_class.new(error + ' Again!') }
+                                 .then { |_value| raise "This won't ever run!" }
+      end
+
+      it { expect(chain).to be_failed }
+
+      it 'executes the catch block ' do
+        expect(chain.error).to eq('This... Fails! Again!')
+      end
+    end
   end
 
   describe '#on_failure' do

--- a/spec/f_service/result/success_spec.rb
+++ b/spec/f_service/result/success_spec.rb
@@ -63,6 +63,22 @@ RSpec.describe FService::Result::Success do
         expect(chain.value).to eq('Yay! It works! Type: ok!')
       end
     end
+
+    context 'when chaining results with a catch block using the `or` alias' do
+      subject(:chain) do
+        described_class.new('Yay!')
+                       .or { FService::Result::Failure.new('Shoot! It failed!') }
+                       .then { |value| described_class.new(value + ' It') }
+                       .then { |value| described_class.new(value + ' works!', :ok) }
+                       .then { |value, type| described_class.new(value + " Type: #{type}!") }
+      end
+
+      it { expect(chain).to be_successful }
+
+      it 'chains successful results' do
+        expect(chain.value).to eq('Yay! It works! Type: ok!')
+      end
+    end
   end
 
   describe '#on_success' do

--- a/spec/f_service/result/success_spec.rb
+++ b/spec/f_service/result/success_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe FService::Result::Success do
         expect(chain.value).to eq('Yay! It works! Type: ok!')
       end
     end
+
+    context 'when chaining results with a catch block' do
+      subject(:chain) do
+        described_class.new('Yay!')
+                       .catch { FService::Result::Failure.new('Shoot! It failed!') }
+                       .then { |value| described_class.new(value + ' It') }
+                       .then { |value| described_class.new(value + ' works!', :ok) }
+                       .then { |value, type| described_class.new(value + " Type: #{type}!") }
+      end
+
+      it { expect(chain).to be_successful }
+
+      it 'chains successful results' do
+        expect(chain.value).to eq('Yay! It works! Type: ok!')
+      end
+    end
   end
 
   describe '#on_success' do


### PR DESCRIPTION
Adds the .catch method that runs similarly to .then, but only on Result::Failure instances

```ruby
Example::Service.(args)
    .catch { ... } #runs only if Result is a Failure
```