### PR TITLE
Add support to multiple values on on_success and on_failure hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (master)
 ### Added
-- Adds support to multiple type checks on `Result#on_success` and `Result#on_failure` hooks.
+- Add support to multiple type checks on `Result#on_success` and `Result#on_failure` hooks.
 - Yields result type on blocks (`then`, `on_success` and `on_failure`).
 - Add type check on `Result#on_success` and `Result#on_failure` hooks.
 - Add method `Base#Try`. It wraps exceptions in Failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (master)
 ### Added
-- Yields result type on blocks (`then`, `on_success` and `on_failure`)
+- Adds support to multiple type checks on `Result#on_success` and `Result#on_failure` hooks.
+- Yields result type on blocks (`then`, `on_success` and `on_failure`).
 - Add type check on `Result#on_success` and `Result#on_failure` hooks.
 - Add method `Base#Try`. It wraps exceptions in Failures.
 - Add method `Base#Check`. It converts booleans to Results.

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -52,11 +52,13 @@ module FService
       end
 
       # This hook runs if the result is successful.
+      # Can receive one or more types to be checked before running the given block.
       #
       # @example
       #   class UsersController < BaseController
       #     def update
       #       User::Update.(user: user)
+      #                   .on_success(:type, :type2) { return json_success({ status: :ok }) } # run only if type matches
       #                   .on_success { |value| return json_success(value) }
       #                   .on_failure { |error| return json_error(error) } # this won't run
       #     end
@@ -72,19 +74,21 @@ module FService
       # @yieldparam type type of the failure object
       # @return [Success, Failure] the original Result object
       # @api public
-      def on_success(target_type = nil)
-        yield(*to_ary) if successful? && expected_type?(target_type)
+      def on_success(*target_types)
+        yield(*to_ary) if successful? && expected_type?(target_types)
 
         self
       end
 
       # This hook runs if the result is failed.
+      # Can receive one or more types to be checked before running the given block.
       #
       # @example
       #   class UsersController < BaseController
       #     def update
       #       User::Update.(user: user)
       #                   .on_success { |value| return json_success(value) } # this won't run
+      #                   .on_failure(:type, :type2) { |error| return json_error(error) } # runs only if type matches
       #                   .on_failure { |error| return json_error(error) }
       #     end
       #
@@ -99,8 +103,8 @@ module FService
       # @yieldparam type type of the failure object
       # @return [Success, Failure] the original Result object
       # @api public
-      def on_failure(target_type = nil)
-        yield(*to_ary) if failed? && expected_type?(target_type)
+      def on_failure(*target_types)
+        yield(*to_ary) if failed? && expected_type?(target_types)
 
         self
       end
@@ -116,8 +120,8 @@ module FService
 
       private
 
-      def expected_type?(target_type)
-        type == target_type || target_type.nil?
+      def expected_type?(target_types)
+        target_types.include?(type) || target_types.empty?
       end
     end
   end

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe FService::Result::Failure do
       failure.on_failure { |value| value << 1 }
              .on_failure(:error) { |value, type| value << type }
              .on_failure(:other_error) { |value| value << 3 }
+             .on_failure(:error, :other_error, :another_error) do |value|
+               value << "That's no moon"
+             end
     end
 
     let(:array) { [] }
@@ -65,7 +68,7 @@ RSpec.describe FService::Result::Failure do
     it 'evaluates the given block on failure' do
       on_failure_callback
 
-      expect(array).to eq [1, :error]
+      expect(array).to eq [1, :error, "That's no moon"]
     end
   end
 
@@ -74,6 +77,7 @@ RSpec.describe FService::Result::Failure do
       failure.on_success { |value| value << 1 }
              .on_success(:error) { |value| value << 2 }
              .on_success { raise "This won't ever run" }
+             .on_success(:error, :other_error) { raise 'Chewbacca is a Wookie warrior' }
     end
 
     let(:array) { [] }

--- a/spec/f_service/result/success_spec.rb
+++ b/spec/f_service/result/success_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe FService::Result::Success do
       success.on_success { |value| value << 1 }
              .on_success(:ok) { |value, type| value << type }
              .on_success(:still_ok) { |value| value << 3 }
+             .on_success(:ok, :still_ok) { |value| value << 'one more time' }
     end
 
     let(:array) { [] }
@@ -66,7 +67,7 @@ RSpec.describe FService::Result::Success do
     it 'evaluates the given block on success' do
       on_success_callback
 
-      expect(array).to eq [1, :ok]
+      expect(array).to eq [1, :ok, 'one more time']
     end
   end
 
@@ -75,6 +76,7 @@ RSpec.describe FService::Result::Success do
       success.on_failure { |value| value << 1 }
              .on_failure(:ok) { |value| value << 2 }
              .on_failure { raise "This won't ever run" }
+             .on_failure(:ok, :not_ok) { raise 'This is a contradiction' }
     end
 
     let(:array) { [] }


### PR DESCRIPTION
Solves #9.

This pull request adds support on the `on_success` and `on_failure`, now this is possible:

```ruby
SomeService.(some_argument)
    .on_failure(:type1, :type2) { some_code }
    .on_failure(:type3) { more_code }
    .on_success  { successful_code }
```