### PR TITLE
Add data prop to FService::Base#Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (master)
 ### Added
+- Add support to custom `data` property to be passed when calling `Base#Check`.
 - Add support to multiple type checks on `Result#on_success` and `Result#on_failure` hooks.
 - Yields result type on blocks (`then`, `on_success` and `on_failure`).
 - Add type check on `Result#on_success` and `Result#on_failure` hooks.

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -146,8 +146,9 @@ module FService
 
     # Converts a boolean to a Result.
     # Truthy values map to Success, and falsey values map to Failures.
-    # You can optionally provide a type for the result. The result value
-    # is the evaluated value of the given block.
+    # You can optionally provide a type for the result.
+    # The result value defaults as the evaluated value of the given block,
+    # if you want another value you can pass it through the data argument.
     #
     # @example
     #   class CheckMathWorks < FService::Base
@@ -157,13 +158,20 @@ module FService
     #
     #       Check(:math_works) { 1 > 2 }
     #       # => #<Failure @error=false, @type=:math_works>
+    #
+    #       Check(:math_works, data: 1 + 2) { 1 > 2 }
+    #       # => #<Failure @error=false, @type=:math_works, @error=3>
     #     end
     #   end
     #
     # @param type the Result type
     # @return [Result::Success, Result::Failure] a Result from the boolean expression
-    def Check(type = nil)
+    def Check(type = nil, data: nil)
       res = yield
+
+      unless data.nil?
+        return res ? Success(type, data: data) : Failure(type, data: data)
+      end
 
       res ? Success(type, data: res) : Failure(type, data: res)
     end

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -160,7 +160,11 @@ module FService
     #       # => #<Failure @error=false, @type=:math_works>
     #
     #       Check(:math_works, data: 1 + 2) { 1 > 2 }
-    #       # => #<Failure @error=false, @type=:math_works, @error=3>
+    #       # => #<Failure @type=:math_works, @error=3>
+    #     end
+    #
+    #       Check(:math_works, data: 1 + 2) { 1 < 2 }
+    #       # => #<Success @type=:math_works, @value=3>
     #     end
     #   end
     #

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe FService::Base do
       it { expect(response.type).to eq(nil) }
       it { expect(response.error).to eq(false) }
     end
+
+    context 'when data is passed' do
+      subject(:response) { described_class.new.Check(data: 'that is an error') { 1 > 2 } }
+
+      it { expect(response).to be_failed }
+      it { expect(response.type).to eq(nil) }
+      it { expect(response.error).to eq('that is an error') }
+    end
   end
 
   describe '#Try' do


### PR DESCRIPTION
hey,

everytime myself and my colleages use the `FService::Base#Check` method we end up with the problem of not being able to pass a custom data to the resulting `Result`. In the end, we end up writing code very similar to what the gem does in the method definition.

Closes #19 