### PR TITLE
Deprecate method #then for Success and Failure classes

### DIFF
--- a/lib/f_service.rb
+++ b/lib/f_service.rb
@@ -10,11 +10,11 @@ module FService
   #
   # @api private
   def self.deprecate!(name:, alternative:, from: nil)
-    warn_message = ["[DEPRECATED] #{name} is deprecated; "]
+    warn_message = ["\n[DEPRECATED] #{name} is deprecated; "]
     warn_message << ["called from #{from}; "] unless from.nil?
     warn_message << "use #{alternative} instead. "
     warn_message << 'It will be removed on the next release.'
 
-    warn warn_message.join
+    warn warn_message.join("\n")
   end
 end

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -101,7 +101,8 @@ module FService
     def success(data = nil)
       FService.deprecate!(
         name: "#{self.class}##{__method__}",
-        alternative: '#Success'
+        alternative: '#Success',
+        from: caller[0]
       )
 
       Result::Success.new(data)
@@ -250,7 +251,8 @@ module FService
     def failure(data = nil)
       FService.deprecate!(
         name: "#{self.class}##{__method__}",
-        alternative: '#Failure'
+        alternative: '#Failure',
+        from: caller[0]
       )
 
       Result::Failure.new(data)
@@ -283,7 +285,8 @@ module FService
     def result(condition, data = nil)
       FService.deprecate!(
         name: "#{self.class}##{__method__}",
-        alternative: '#Check'
+        alternative: '#Check',
+        from: caller[0]
       )
 
       condition ? success(data) : failure(data)

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -110,7 +110,12 @@ module FService
       def and_then
         self
       end
-      alias then and_then
+
+      # See #and_then
+      def then
+        FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#and_then', from: caller[0])
+        and_then
+      end
 
       # Outputs a string representation of the object
       #

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -83,7 +83,13 @@ module FService
       def and_then
         yield(*to_ary)
       end
-      alias then and_then
+
+      # See #and_then
+      def then(&block)
+        FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#and_then', from: caller[0])
+
+        and_then(&block)
+      end
 
       # Returns itself to the given block.
       # Use this to chain multiple actions or service calls (only valid when they return a Result).

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -141,15 +141,19 @@ RSpec.describe FService::Result::Failure do
   describe '#then' do
     subject(:failure) { described_class.new('Pax', :ok) }
 
+    before { allow(FService).to receive(:deprecate!) }
+
     context 'when a block is given' do
-      it 'returns itself' do
+      it 'returns itself', :aggregate_failures do
         expect(failure.then { 'an error happened' }).to eq(failure)
+        expect(FService).to have_received(:deprecate!)
       end
     end
 
     context 'when a block is passed as argument' do
-      it 'does not yields the block' do
+      it 'does not yields the block', :aggregate_failures do
         expect { |block| failure.then(&block) }.not_to yield_control
+        expect(FService).to have_received(:deprecate!)
       end
     end
   end

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -125,12 +125,32 @@ RSpec.describe FService::Result::Failure do
   describe '#and_then' do
     subject(:failure) { described_class.new('Pax', :ok) }
 
-    it 'does not yields the block' do
-      expect { |block| failure.and_then(&block) }.not_to yield_control
+    context 'when a block is given' do
+      it 'returns itself' do
+        expect(failure.and_then { 'an error happened' }).to eq(failure)
+      end
     end
 
-    it 'returns itself' do
-      expect(failure.and_then { 'an error happened' }).to eq(failure)
+    context 'when a block is passed as argument' do
+      it 'does not yields the block' do
+        expect { |block| failure.and_then(&block) }.not_to yield_control
+      end
+    end
+  end
+
+  describe '#then' do
+    subject(:failure) { described_class.new('Pax', :ok) }
+
+    context 'when a block is given' do
+      it 'returns itself' do
+        expect(failure.then { 'an error happened' }).to eq(failure)
+      end
+    end
+
+    context 'when a block is passed as argument' do
+      it 'does not yields the block' do
+        expect { |block| failure.then(&block) }.not_to yield_control
+      end
     end
   end
 

--- a/spec/f_service/result/success_spec.rb
+++ b/spec/f_service/result/success_spec.rb
@@ -134,17 +134,21 @@ RSpec.describe FService::Result::Success do
   describe '#then' do
     subject(:success) { described_class.new('Pax', :ok) }
 
+    before { allow(FService).to receive(:deprecate!) }
+
     context 'when a block is given' do
-      it 'returns the given block result' do
+      it 'returns the given block result', :aggregate_failures do
         expect(success.then { |value| "Hello, #{value}!" }).to eq('Hello, Pax!')
+        expect(FService).to have_received(:deprecate!)
       end
     end
 
     context 'when a block is passed as argument' do
-      it 'returns the given block argument' do
+      it 'returns the given block argument', :aggregate_failures do
         block = ->(value, _type) { "Hello, #{value}!" }
 
         expect(success.then(&block)).to eq('Hello, Pax!')
+        expect(FService).to have_received(:deprecate!)
       end
     end
   end

--- a/spec/f_service/result/success_spec.rb
+++ b/spec/f_service/result/success_spec.rb
@@ -116,8 +116,36 @@ RSpec.describe FService::Result::Success do
   describe '#and_then' do
     subject(:success) { described_class.new('Pax', :ok) }
 
-    it 'returns the given block result' do
-      expect(success.and_then { |value| "Hello, #{value}!" }).to eq('Hello, Pax!')
+    context 'when a block is given' do
+      it 'returns the given block result' do
+        expect(success.and_then { |value| "Hello, #{value}!" }).to eq('Hello, Pax!')
+      end
+    end
+
+    context 'when a block is passed as argument' do
+      it 'returns the given block argument' do
+        block = ->(value, _type) { "Hello, #{value}!" }
+
+        expect(success.and_then(&block)).to eq('Hello, Pax!')
+      end
+    end
+  end
+
+  describe '#then' do
+    subject(:success) { described_class.new('Pax', :ok) }
+
+    context 'when a block is given' do
+      it 'returns the given block result' do
+        expect(success.then { |value| "Hello, #{value}!" }).to eq('Hello, Pax!')
+      end
+    end
+
+    context 'when a block is passed as argument' do
+      it 'returns the given block argument' do
+        block = ->(value, _type) { "Hello, #{value}!" }
+
+        expect(success.then(&block)).to eq('Hello, Pax!')
+      end
     end
   end
 


### PR DESCRIPTION
Following the suggested step in this issue https://github.com/Fretadao/f_service/issues/23 we are deprecating then method before removing this.