### PR TITLE
Add multiple success failures types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 ### Added
-
-- Rspec Helper mock_service;
-- Rspec Matcher have_succeed_with and have_failed_with
+- Add Rspec Helper mock_service;
+- Add Rspec Matcher have_succeed_with and have_failed_with;
+- Add `Success()`, `Failure()`, `Check()`, `Try()` now can be multipe types;
 
 ## 0.2.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Rspec Helper mock_service;
 - Add Rspec Matcher have_succeed_with and have_failed_with;
 - Add `Success()`, `Failure()`, `Check()`, `Try()` now can be multipe types;
+- Changed depreacate `Result#type` method.
 
 ## 0.2.0
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GEM
     jaro_winkler (1.5.4)
     maruku (0.7.3)
     method_source (1.0.0)
-    mini_portile2 (2.8.0)
-    nokogiri (1.13.10)
+    mini_portile2 (2.8.1)
+    nokogiri (1.14.1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.19.1)
@@ -28,7 +28,7 @@ GEM
       method_source (~> 1.0)
     pry-nav (1.0.0)
       pry (>= 0.9.10, < 0.15)
-    racc (1.6.1)
+    racc (1.6.2)
     rainbow (3.0.0)
     rake (13.0.1)
     reverse_markdown (1.4.0)
@@ -100,4 +100,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ mock_service(Uer::Create, result: :success, types: :created, value: instance_spy
 mock_service(Uer::Create, result: :failure)
 # => Mocs a failure with all nil values
 
-mock_service(Uer::Create, result: :failure, type: [:unprocessable_entity, :client_error])
+mock_service(User::Create, result: :failure, types: [:unprocessable_entity, :client_error])
 # => Mocs a failure with a failure type
 
-mock_service(Uer::Create, result: :failure, type: [:unprocessable_entity, :client_error], value: { name: ["can't be blank"] })
+mock_service(User::Create, result: :failure, types: [:unprocessable_entity, :client_error], value: { name: ["can't be blank"] })
 # => Mocs a failure with a failure type and an error value
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ end
 
 The next step is writing the `#run` method, which is where the work should be done.
 Use the methods `#Success` and `#Failure` to handle your return values.
-You can optionally specify a type and a value for your result.
+You can optionally specify a list of types which represents that result and a value for your result.
 
 ```ruby
 class User::Create < FService::Base
   # ...
   def run
-    return Failure(:no_name) if @name.nil?
+    return Failure(:no_name, :invalid_attribute) if @name.nil?
 
     user = UserRepository.create(name: @name)
     if user.save
@@ -232,7 +232,7 @@ Check(:math_works) { 1 < 2 }
 # => #<Success @value=true, @types=[:math_works]>
 
 Check(:math_works) { 1 > 2 }
-# => #<Failure @error=false, @type=:math_works>
+# => #<Failure @error=false, @types=[:math_works]>
 ```
 
 `Try` transforms an exception into a `Failure` if some exception is raised for the given block. You can specify which exception class to watch for
@@ -254,7 +254,7 @@ IHateEvenNumbers.call
 # => #<Success @value=9, @types=[:rand_int]>
 
 IHateEvenNumbers.call
-# => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @type=:rand_int>
+# => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @types=[:rand_int]>
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ class User::Create < FService::Base
     return Failure(:no_name) if @name.nil?
 
     user = UserRepository.create(name: @name)
-    if user.valid?
-      Success(:created, data: user)
+    if user.save
+      Success(:success, :created, data: user)
     else
       Failure(:creation_failed, data: user.errors)
     end
@@ -229,7 +229,7 @@ You can use `Check` to converts a boolean to a Result, truthy values map to `Suc
 
 ```ruby
 Check(:math_works) { 1 < 2 }
-# => #<Success @value=true, @type=:math_works>
+# => #<Success @value=true, @types=[:math_works]>
 
 Check(:math_works) { 1 > 2 }
 # => #<Failure @error=false, @type=:math_works>
@@ -251,7 +251,7 @@ class IHateEvenNumbers < FService::Base
 end
 
 IHateEvenNumbers.call
-# => #<Success @value=9, @type=:rand_int>
+# => #<Success @value=9, @types=[:rand_int]>
 
 IHateEvenNumbers.call
 # => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @type=:rand_int>

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ class UsersController < BaseController
 end
 ```
 
+### Types precedence
+
+FService matches types from left to right, from more specific to more generic.
+Example (:unprocessable_entity, :client_error, :http_response)
+Then, result will match first :unprocessable_entity, after :client_error, after :http_response, then not matched.
+
 ### Chaining services
 
 Since all services return Results, you can chain service calls making a data pipeline.

--- a/README.md
+++ b/README.md
@@ -278,19 +278,19 @@ mock_service(Uer::Create)
 mock_service(Uer::Create, result: :success)
 # => Mocks a successful result with all values nil
 
-mock_service(Uer::Create, result: :success, type: :created)
+mock_service(Uer::Create, result: :success, types: [:created, :success])
 # => Mocks a successful result with type created
 
-mock_service(Uer::Create, result: :success, type: :created, value: instance_spy(User))
+mock_service(Uer::Create, result: :success, types: :created, value: instance_spy(User))
 # => Mocks a successful result with type created and a value
 
 mock_service(Uer::Create, result: :failure)
 # => Mocs a failure with all nil values
 
-mock_service(Uer::Create, result: :failure, type: :invalid_attributes)
+mock_service(Uer::Create, result: :failure, type: [:unprocessable_entity, :client_error])
 # => Mocs a failure with a failure type
 
-mock_service(Uer::Create, result: :failure, type: :invalid_attributes, value: { name: ["can't be blank"] })
+mock_service(Uer::Create, result: :failure, type: [:unprocessable_entity, :client_error], value: { name: ["can't be blank"] })
 # => Mocs a failure with a failure type and an error value
 ```
 

--- a/lib/f_service.rb
+++ b/lib/f_service.rb
@@ -17,4 +17,16 @@ module FService
 
     warn warn_message.join("\n")
   end
+
+  # Marks an argument as deprecated
+  #
+  # @api private
+  def self.deprecate_argument_name(name:, argument_name:, alternative:, from: nil)
+    warn_message = ["\n[DEPRECATED] #{name} passing #{argument_name.inspect} is deprecated; "]
+    warn_message << ["called from #{from}; "] unless from.nil?
+    warn_message << "use #{alternative} instead. "
+    warn_message << 'It will be removed on the next release.'
+
+    warn warn_message.join("\n")
+  end
 end

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -125,7 +125,7 @@ module FService
     #     # => #<Success @value=10, @types=[]>
     #
     #     Success(:ok, data: 10)
-    #     # => #<Success @value=10, @type=[:ok]>
+    #     # => #<Success @value=10, @types=[:ok]>
     #   end
     #
     # @param types the Result types
@@ -136,30 +136,30 @@ module FService
     end
 
     # Returns a failed result.
-    # You can optionally specify a type and a value for your result.
+    # You can optionally specify types and a value for your result.
     # You'll probably want to return this inside {#run}.
     #
     #
     # @example
     #   def run
     #     Failure()
-    #     # => #<Failure @error=nil, @type=nil>
+    #     # => #<Failure @error=nil, @types=nil>
     #
     #     Failure(:not_a_number)
-    #     # => #<Failure @error=nil, @type=:not_a_number>
+    #     # => #<Failure @error=nil, @types=:not_a_number>
     #
     #     Failure(data: "10")
-    #     # => #<Failure @error="10", @type=nil>
+    #     # => #<Failure @error="10", @types=nil>
     #
     #     Failure(:not_a_number, data: "10")
-    #     # => #<Failure @error="10", @type=:not_a_number>
+    #     # => #<Failure @error="10", @types=:not_a_number>
     #   end
     #
-    # @param type the Result type
+    # @param types the Result types
     # @param data the result value
     # @return [Result::Failure] a failed result
-    def Failure(type = nil, data: nil)
-      Result::Failure.new(data, type)
+    def Failure(*types, data: nil)
+      Result::Failure.new(data, types)
     end
 
     # Converts a boolean to a Result.

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -109,30 +109,30 @@ module FService
     end
 
     # Returns a successful result.
-    # You can optionally specify a type and a value for your result.
+    # You can optionally specify a list of types and a value for your result.
     # You'll probably want to return this inside {#run}.
     #
     #
     # @example
     #   def run
     #     Success()
-    #     # => #<Success @value=nil, @type=nil>
+    #     # => #<Success @value=nil, @types=[]>
     #
     #     Success(:ok)
-    #     # => #<Success @value=nil, @type=:ok>
+    #     # => #<Success @value=nil, @types=[:ok]>
     #
     #     Success(data: 10)
-    #     # => #<Success @value=10, @type=nil>
+    #     # => #<Success @value=10, @types=[]>
     #
     #     Success(:ok, data: 10)
-    #     # => #<Success @value=10, @type=:ok>
+    #     # => #<Success @value=10, @type=[:ok]>
     #   end
     #
-    # @param type the Result type
+    # @param types the Result types
     # @param data the result value
     # @return [Result::Success] a successful result
-    def Success(type = nil, data: nil)
-      Result::Success.new(data, type)
+    def Success(*types, data: nil)
+      Result::Success.new(data, types)
     end
 
     # Returns a failed result.

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -143,16 +143,16 @@ module FService
     # @example
     #   def run
     #     Failure()
-    #     # => #<Failure @error=nil, @types=nil>
+    #     # => #<Failure @error=nil, @types=[]>
     #
     #     Failure(:not_a_number)
-    #     # => #<Failure @error=nil, @types=:not_a_number>
+    #     # => #<Failure @error=nil, @types=[:not_a_number]>
     #
     #     Failure(data: "10")
-    #     # => #<Failure @error="10", @types=nil>
+    #     # => #<Failure @error="10", @types=[]>
     #
     #     Failure(:not_a_number, data: "10")
-    #     # => #<Failure @error="10", @types=:not_a_number>
+    #     # => #<Failure @error="10", @types=[:not_a_number]>
     #   end
     #
     # @param types the Result types
@@ -172,17 +172,17 @@ module FService
     #   class CheckMathWorks < FService::Base
     #     def run
     #       Check(:math_works) { 1 < 2 }
-    #       # => #<Success @value=true, @types=:math_works>
+    #       # => #<Success @value=true, @types=[:math_works]>
     #
     #       Check(:math_works) { 1 > 2 }
-    #       # => #<Failure @error=false, @types=:math_works>
+    #       # => #<Failure @error=false, @types=[:math_works]>
     #
     #       Check(:math_works, data: 1 + 2) { 1 > 2 }
     #       # => #<Failure @types=:math_works, @error=3>
     #     end
     #
     #       Check(:math_works, data: 1 + 2) { 1 < 2 }
-    #       # => #<Success @types=:math_works, @value=3>
+    #       # => #<Success @types=[:math_works], @value=3>
     #     end
     #   end
     #
@@ -199,7 +199,7 @@ module FService
     # If the given block raises an exception, it wraps it in a Failure.
     # Otherwise, maps the block value in a Success object.
     # You can specify which exceptions to watch for.
-    # It's possible to provide a type for the result too.
+    # It's possible to provide a types for the result too.
     #
     # @example
     #   class IHateEvenNumbers < FService::Base
@@ -214,20 +214,20 @@ module FService
     #   end
     #
     #   IHateEvenNumbers.call
-    #   # => #<Success @value=9, @type=:rand_int>
+    #   # => #<Success @value=9, @types=[:rand_int]>
     #
     #   IHateEvenNumbers.call
-    #   # => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @type=:rand_int>
+    #   # => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @types=[:rand_int]>
     #
-    # @param type the Result type
+    # @param types the Result types
     # @param catch the exception list to catch
     # @return [Result::Success, Result::Failure] a result from the boolean expression
-    def Try(type = nil, catch: StandardError)
+    def Try(*types, catch: StandardError)
       res = yield
 
-      Success(type, data: res)
+      Success(*types, data: res)
     rescue *catch => e
-      Failure(type, data: e)
+      Failure(*types, data: e)
     end
 
     # Returns a failed operation.

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -164,7 +164,7 @@ module FService
 
     # Converts a boolean to a Result.
     # Truthy values map to Success, and falsey values map to Failures.
-    # You can optionally provide a type for the result.
+    # You can optionally provide a types for the result.
     # The result value defaults as the evaluated value of the given block.
     # If you want another value you can pass it through the `data:` argument.
     #
@@ -172,28 +172,28 @@ module FService
     #   class CheckMathWorks < FService::Base
     #     def run
     #       Check(:math_works) { 1 < 2 }
-    #       # => #<Success @value=true, @type=:math_works>
+    #       # => #<Success @value=true, @types=:math_works>
     #
     #       Check(:math_works) { 1 > 2 }
-    #       # => #<Failure @error=false, @type=:math_works>
+    #       # => #<Failure @error=false, @types=:math_works>
     #
     #       Check(:math_works, data: 1 + 2) { 1 > 2 }
-    #       # => #<Failure @type=:math_works, @error=3>
+    #       # => #<Failure @types=:math_works, @error=3>
     #     end
     #
     #       Check(:math_works, data: 1 + 2) { 1 < 2 }
-    #       # => #<Success @type=:math_works, @value=3>
+    #       # => #<Success @types=:math_works, @value=3>
     #     end
     #   end
     #
-    # @param type the Result type
+    # @param types the Result types
     # @return [Result::Success, Result::Failure] a Result from the boolean expression
-    def Check(type = nil, data: nil)
+    def Check(*types, data: nil)
       res = yield
 
       final_data = data || res
 
-      res ? Success(type, data: final_data) : Failure(type, data: final_data)
+      res ? Success(*types, data: final_data) : Failure(*types, data: final_data)
     end
 
     # If the given block raises an exception, it wraps it in a Failure.

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -125,7 +125,7 @@ module FService
       def to_ary
         data = successful? ? value : error
 
-        [data, respond_to?(:type) ? type : @matching_types.first]
+        [data, @matching_types.first]
       end
 
       private
@@ -139,18 +139,12 @@ module FService
       end
 
       def expected_type?(target_types, unhandled:)
-        if respond_to?(:type)
-          target_types.empty? || unhandled || target_types.include?(type)
-        else
-          target_types.empty? || unhandled || target_types.any? { |target_type| types.include?(target_type) }
-        end
+        target_types.empty? || unhandled || target_types.any? { |target_type| types.include?(target_type) }
       end
 
       def match_types(target_types)
         @matching_types = if target_types.empty?
                             []
-                          elsif respond_to?(:type)
-                            type
                           else
                             target_types & types
                           end

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -19,6 +19,13 @@ module FService
         @matching_types = []
       end
 
+      # Implements old attribute type. Its deprecated in favor of using types.
+      def type
+        FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#types', from: caller[0])
+
+        Array(@matching_types).first
+      end
+
       # This hook runs if the result is successful.
       # Can receive one or more types to be checked before running the given block.
       #

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -7,6 +7,8 @@ module FService
     #
     # @abstract
     class Base
+      attr_reader :types
+
       %i[and_then successful? failed? value value! error].each do |method_name|
         define_method(method_name) do |*_args|
           raise NotImplementedError, "called #{method_name} on class Result::Base"
@@ -14,8 +16,9 @@ module FService
       end
 
       # You usually shouldn't call this directly. See {FService::Base#Failure} and {FService::Base#Success}.
-      def initialize
+      def initialize(types = [])
         @handled = false
+        @types = types
         @matching_types = []
       end
 
@@ -23,7 +26,7 @@ module FService
       def type
         FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#types', from: caller[0])
 
-        Array(@matching_types).first
+        types.size == 1 ? types.first : Array(@matching_types).first
       end
 
       # This hook runs if the result is successful.

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -143,11 +143,7 @@ module FService
       end
 
       def match_types(target_types)
-        @matching_types = if target_types.empty?
-                            []
-                          else
-                            target_types & types
-                          end
+        @matching_types = target_types.empty? ? types : target_types & types
       end
     end
   end

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -110,6 +110,7 @@ module FService
       # @api public
       def on_failure(*target_types, unhandled: false)
         if failed? && unhandled? && expected_type?(target_types, unhandled: unhandled)
+          match_types(target_types)
           yield(*to_ary)
           @handled = true
           freeze

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -10,20 +10,20 @@ module FService
     #
     # @!attribute [r] error
     #   @return [Object] the provided error for the result
-    # @!attribute [r] type
-    #   @return [Object] the provided type for the result. Defaults to nil.
+    # @!attribute [r] types
+    #   @return [Object] the provided types for the result. Defaults to nil.
     # @api public
     class Failure < Result::Base
-      attr_reader :error, :type
+      attr_reader :error, :types
 
       # Creates a failed operation.
       # You usually shouldn't call this directly. See {FService::Base#Failure}.
       #
       # @param error [Object] failure value.
-      def initialize(error, type = nil)
+      def initialize(error, types = [])
         super()
         @error = error
-        @type = type
+        @types = types
       end
 
       # Returns false.

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -14,16 +14,15 @@ module FService
     #   @return [Object] the provided types for the result. Defaults to nil.
     # @api public
     class Failure < Result::Base
-      attr_reader :error, :types
+      attr_reader :error
 
       # Creates a failed operation.
       # You usually shouldn't call this directly. See {FService::Base#Failure}.
       #
       # @param error [Object] failure value.
       def initialize(error, types = [])
-        super()
+        super(types)
         @error = error
-        @types = types
       end
 
       # Returns false.

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -13,16 +13,15 @@ module FService
     #   @return [Object] the provided types for the result. Defaults to nil.
     # @api public
     class Success < Result::Base
-      attr_reader :value, :types
+      attr_reader :value
 
       # Creates a successful operation.
       # You usually shouldn't call this directly. See {FService::Base#Success}.
       #
       # @param value [Object] success value.
       def initialize(value, types = [])
-        super()
+        super(types)
         @value = value
-        @types = types
       end
 
       # Returns true.

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -9,20 +9,20 @@ module FService
     #
     # @!attribute [r] value
     #   @return [Object] the provided value for the result
-    # @!attribute [r] type
-    #   @return [Object] the provided type for the result. Defaults to nil.
+    # @!attribute [r] types
+    #   @return [Object] the provided types for the result. Defaults to nil.
     # @api public
     class Success < Result::Base
-      attr_reader :value, :type
+      attr_reader :value, :types
 
       # Creates a successful operation.
       # You usually shouldn't call this directly. See {FService::Base#Success}.
       #
       # @param value [Object] success value.
-      def initialize(value, type = nil)
+      def initialize(value, types = [])
         super()
         @value = value
-        @type = type
+        @types = types
       end
 
       # Returns true.
@@ -79,7 +79,7 @@ module FService
       #   end
       #
       # @yieldparam value pass {#value} to a block
-      # @yieldparam type pass {#type} to a block
+      # @yieldparam types pass {#types} to a block
       def and_then
         yield(*to_ary)
       end

--- a/lib/f_service/rspec/support/helpers/result.rb
+++ b/lib/f_service/rspec/support/helpers/result.rb
@@ -5,9 +5,9 @@ module FServiceResultHelpers
   # Create an Fservice result Success or Failure.
   def f_service_result(result, value = nil, types = [])
     if result == :success
-      FService::Result::Success.new(value, *Array(types))
+      FService::Result::Success.new(value, Array(types))
     else
-      FService::Result::Failure.new(value, *Array(types))
+      FService::Result::Failure.new(value, Array(types))
     end
   end
 

--- a/lib/f_service/rspec/support/helpers/result.rb
+++ b/lib/f_service/rspec/support/helpers/result.rb
@@ -3,17 +3,26 @@
 # Methods to mock a FService result from a service call.
 module FServiceResultHelpers
   # Create an Fservice result Success or Failure.
-  def f_service_result(result, value = nil, type = nil)
+  def f_service_result(result, value = nil, types = [])
     if result == :success
-      FService::Result::Success.new(value, type)
+      FService::Result::Success.new(value, *Array(types))
     else
-      FService::Result::Failure.new(value, type)
+      FService::Result::Failure.new(value, *Array(types))
     end
   end
 
   # Mock a Fservice service call returning a result.
-  def mock_service(service, result: :success, value: nil, type: nil)
-    service_result = f_service_result(result, value, type)
+  def mock_service(service, result: :success, value: nil, type: :not_passed, types: [])
+    result_types = Array(types)
+
+    if type != :not_passed
+      alternative = "mock_service(..., types: [#{type.inspect}])"
+      name = 'mock_service'
+      FService.deprecate_argument_name(name: name, argument_name: :type, alternative: alternative, from: caller[0])
+      result_types = Array(type)
+    end
+
+    service_result = f_service_result(result, value, result_types)
     allow(service).to receive(:call).and_return(service_result)
   end
 end

--- a/lib/f_service/rspec/support/matchers/result.rb
+++ b/lib/f_service/rspec/support/matchers/result.rb
@@ -33,6 +33,7 @@ end
 
 RSpec::Matchers.define :have_succeed_with do |*expected_types|
   match do |actual|
+    binding.pry
     matched = actual.is_a?(FService::Result::Success) && actual.types == expected_types
 
     matched &&= values_match?(@expected_value, actual.value) if defined?(@expected_value)

--- a/lib/f_service/rspec/support/matchers/result.rb
+++ b/lib/f_service/rspec/support/matchers/result.rb
@@ -2,9 +2,9 @@
 
 require 'rspec/expectations'
 
-RSpec::Matchers.define :have_failed_with do |expected|
+RSpec::Matchers.define :have_failed_with do |*expected_types|
   match do |actual|
-    matched = actual.is_a?(FService::Result::Failure) && actual.type == expected
+    matched = actual.is_a?(FService::Result::Failure) && actual.types == expected_types
 
     matched &&= actual.error == @expected_error if defined?(@expected_error)
 
@@ -17,7 +17,7 @@ RSpec::Matchers.define :have_failed_with do |expected|
 
   failure_message do |actual|
     if actual.is_a?(FService::Result::Failure)
-      message = "expected failure's type '#{actual.type.inspect}' to be equal '#{expected.inspect}'"
+      message = "expected failure's types '#{actual.types.inspect}' to be equal '#{expected_types.inspect}'"
       if defined?(@expected_error)
         has_description = @expected_error.respond_to?(:description)
         message += " and error '#{actual.error.inspect}' to be "
@@ -31,9 +31,9 @@ RSpec::Matchers.define :have_failed_with do |expected|
   end
 end
 
-RSpec::Matchers.define :have_succeed_with do |expected|
+RSpec::Matchers.define :have_succeed_with do |*expected_types|
   match do |actual|
-    matched = actual.is_a?(FService::Result::Success) && actual.type == expected
+    matched = actual.is_a?(FService::Result::Success) && actual.types == expected_types
 
     matched &&= values_match?(@expected_value, actual.value) if defined?(@expected_value)
 
@@ -46,7 +46,7 @@ RSpec::Matchers.define :have_succeed_with do |expected|
 
   failure_message do |actual|
     if actual.is_a?(FService::Result::Success)
-      message = "expected success's type '#{actual.type.inspect}' to be equal '#{expected.inspect}'"
+      message = "expected success's types '#{actual.types.inspect}' to be equal '#{expected_types.inspect}'"
       if defined?(@expected_value)
         has_description = @expected_value.respond_to?(:description)
         message += " and value '#{actual.value.inspect}' to be "

--- a/lib/f_service/rspec/support/matchers/result.rb
+++ b/lib/f_service/rspec/support/matchers/result.rb
@@ -33,7 +33,6 @@ end
 
 RSpec::Matchers.define :have_succeed_with do |*expected_types|
   match do |actual|
-    binding.pry
     matched = actual.is_a?(FService::Result::Success) && actual.types == expected_types
 
     matched &&= values_match?(@expected_value, actual.value) if defined?(@expected_value)

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe FService::Base do
   describe '#Failure' do
     subject(:response) { described_class.new.Failure(:error, data: 'Whoops!') }
 
-    it { expect(response.type).to eq(:error) }
+    it { expect(response.types).to contain_exactly(:error) }
     it { expect(response.error).to eq('Whoops!') }
   end
 
@@ -42,23 +42,23 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Check(:math_works) { 1 > 2 } }
 
       it { expect(response).to be_failed }
-      it { expect(response.type).to eq(:math_works) }
-      it { expect(response.error).to eq(false) }
+      it { expect(response.types).to contain_exactly(:math_works) }
+      it { expect(response.error).to be_falsy }
     end
 
     context 'when type is not specified' do
       subject(:response) { described_class.new.Check { 1 > 2 } }
 
       it { expect(response).to be_failed }
-      it { expect(response.type).to eq(nil) }
-      it { expect(response.error).to eq(false) }
+      it { expect(response.types).to contain_exactly(nil) }
+      it { expect(response.error).to be_falsy }
     end
 
     context 'when data is passed' do
       subject(:response) { described_class.new.Check(data: 'that is an error') { 1 > 2 } }
 
       it { expect(response).to be_failed }
-      it { expect(response.type).to eq(nil) }
+      it { expect(response.types).to contain_exactly(nil) }
       it { expect(response.error).to eq('that is an error') }
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Try(:division) { 1 / 0 } }
 
       it { expect(response).to be_failed }
-      it { expect(response.type).to eq(:division) }
+      it { expect(response.types).to contain_exactly(:division) }
       it { expect(response.error).to be_a ZeroDivisionError }
     end
 

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Try { 0 / 1 } }
 
       it { expect(response).to be_successful }
-      it { expect(response.types).to be_blank }
+      it { expect(response.types).to be_empty }
       it { expect(response.value!).to be_zero }
     end
 

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FService::Base do
   describe '#Success' do
     subject(:response) { described_class.new.Success(:ok, data: 'yay!') }
 
-    it { expect(response.type).to eq(:ok) }
+    it { expect(response.types).to contain_exactly(:ok) }
     it { expect(response.value).to eq('yay!') }
   end
 
@@ -34,8 +34,8 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Check(:math_works) { 1 < 2 } }
 
       it { expect(response).to be_successful }
-      it { expect(response.type).to eq(:math_works) }
-      it { expect(response.value!).to eq(true) }
+      it { expect(response.types).to contain_exactly(:math_works) }
+      it { expect(response.value!).to be_truthy }
     end
 
     context 'when block evaluates to false' do
@@ -67,8 +67,8 @@ RSpec.describe FService::Base do
     subject(:response) { described_class.new.Try(:division) { 0 / 1 } }
 
     it { expect(response).to be_successful }
-    it { expect(response.type).to eq(:division) }
-    it { expect(response.value!).to eq(0) }
+    it { expect(response.types).to contain_exactly(:division) }
+    it { expect(response.value!).to be_zero }
 
     context 'when some exception is raised' do
       subject(:response) { described_class.new.Try(:division) { 1 / 0 } }
@@ -82,8 +82,8 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Try { 0 / 1 } }
 
       it { expect(response).to be_successful }
-      it { expect(response.type).to eq(nil) }
-      it { expect(response.value!).to eq 0 }
+      it { expect(response.types).to contain_exactly(nil) }
+      it { expect(response.value!).to be_zero }
     end
 
     context 'when raised exception does not match specified exception' do

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Check { 1 > 2 } }
 
       it { expect(response).to be_failed }
-      it { expect(response.types).to contain_exactly(nil) }
+      it { expect(response.types).to be_empty }
       it { expect(response.error).to be_falsy }
     end
 
@@ -58,7 +58,7 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Check(data: 'that is an error') { 1 > 2 } }
 
       it { expect(response).to be_failed }
-      it { expect(response.types).to contain_exactly(nil) }
+      it { expect(response.types).to be_empty }
       it { expect(response.error).to eq('that is an error') }
     end
   end

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FService::Base do
       subject(:response) { described_class.new.Try { 0 / 1 } }
 
       it { expect(response).to be_successful }
-      it { expect(response.types).to contain_exactly(nil) }
+      it { expect(response.types).to be_blank }
       it { expect(response.value!).to be_zero }
     end
 

--- a/spec/f_service/result/base_spec.rb
+++ b/spec/f_service/result/base_spec.rb
@@ -3,19 +3,34 @@
 require 'spec_helper'
 
 RSpec.describe FService::Result::Base do
-  let(:test_class) do
-    Class.new(described_class) do
-      def initialize; end
+  describe 'not implmented methods' do
+    let(:test_class) { Class.new(described_class) }
+
+    %i[and_then successful? failed? value value! error].each do |method_name|
+      context 'when subclasses do not override methods' do
+        subject(:method_call) { test_class.new.public_send(method_name) }
+
+        it "raises error on '#{method_name}' call" do
+          expect { method_call }.to raise_error NotImplementedError, "called #{method_name} on class Result::Base"
+        end
+      end
     end
   end
 
-  %i[and_then successful? failed? value value! error].each do |method_name|
-    context 'when subclasses do not override methods' do
-      subject(:method_call) { test_class.new.public_send(method_name) }
-
-      it "raises error on '#{method_name}' call" do
-        expect { method_call }.to raise_error NotImplementedError, "called #{method_name} on class Result::Base"
+  describe '#type' do
+    let(:test_class) do
+      Class.new(described_class) do
+        def initialize
+          @matching_types = %i[ok success]
+        end
       end
+    end
+
+    before { allow(FService).to receive(:deprecate!) }
+
+    it 'deprecates this method', :aggregate_failures do
+      expect(test_class.new.type).to eq(:ok)
+      expect(FService).to have_received(:deprecate!)
     end
   end
 end

--- a/spec/f_service/result/base_spec.rb
+++ b/spec/f_service/result/base_spec.rb
@@ -18,19 +18,37 @@ RSpec.describe FService::Result::Base do
   end
 
   describe '#type' do
-    let(:test_class) do
-      Class.new(described_class) do
-        def initialize
-          @matching_types = %i[ok success]
+    before { allow(FService).to receive(:deprecate!) }
+
+    context 'when types has just one type' do
+      let(:test_class) do
+        Class.new(described_class) do
+          def initialize
+            @types = %i[success]
+          end
         end
+      end
+
+      it 'deprecates this method', :aggregate_failures do
+        expect(test_class.new.type).to eq(:success)
+        expect(FService).to have_received(:deprecate!)
       end
     end
 
-    before { allow(FService).to receive(:deprecate!) }
+    context 'when types has multiple values' do
+      let(:test_class) do
+        Class.new(described_class) do
+          def initialize
+            @types = %i[ok success http_response]
+            @matching_types = %i[ok success]
+          end
+        end
+      end
 
-    it 'deprecates this method', :aggregate_failures do
-      expect(test_class.new.type).to eq(:ok)
-      expect(FService).to have_received(:deprecate!)
+      it 'deprecates this method', :aggregate_failures do
+        expect(test_class.new.type).to eq(:ok)
+        expect(FService).to have_received(:deprecate!)
+      end
     end
   end
 end

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe FService::Result::Failure do
     describe 'return' do
       subject(:on_failure_callback) { failure.on_failure(unhandled: true) { 'some recovering' } }
 
-      let(:failure) { described_class.new([], :error) }
+      let(:failure) { described_class.new([], [:error]) }
 
       it 'returns itself' do
         expect(on_failure_callback).to eq failure
@@ -37,7 +37,7 @@ RSpec.describe FService::Result::Failure do
         subject(:on_failure_callback) { failure.on_failure { |array| array << "That's no moon" } }
 
         let(:array) { [] }
-        let(:failure) { described_class.new(array, :error) }
+        let(:failure) { described_class.new(array, [:error]) }
 
         before { allow(FService).to receive(:deprecate!) }
 


### PR DESCRIPTION
# Allow Success, Failure, Check and Try to be multiple Types.

Closes issue: https://github.com/Fretadao/f_service/issues/39

This allows success or failure to be more than one type...
A real-world example of this use is an HTTP client where we want to give provide different rescues for different HTTP codes, but same treatment for any other code for the family. For example:

```rb
User::Save(attrs: { name: 'Joe' })
  .on_success(:created) { return 'User created' }
  .on_success(:ok) { return 'User Updated' }
  .on_success { return 'User Saved' }
  .on_failure(:unprocessable_entity) { |error| return "Invalid attributes #{error}" }
  .on_failure(:conflict) { return "User already exist." }
  .on_failure(:too_many_requests) { return 'You reached your limit. Try again latter' }
  .on_failure(:bad_gateway, :gateway_timeout, :service_unavailable, :internal_server_error) { |return| return 'temporary trouble. try again latter' }
  .on_failure(:client_error, :server_error) do |error|
    Sentry.capture_exception("Some unexpected client error happened: #{error}")
    return "Unknow error happened, please contact system administration"
  end
```