### PR TITLE
Fix: allow and_error matcher to use RSpec matcher as and_value does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Drop Support to Ruby 2.6 and 2.7
  - Add Support to Ruby 3.2 and 3.3
+ - Changed and_error to use a matcher instead of equality comparation #51
 
 ## 0.3.0
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ require 'f_service/rspec'
 
 ### Mocking a result
 
-```
+```rb
 mock_service(Uer::Create)
 # => Mocks a successful result with all values nil
 
@@ -313,6 +313,8 @@ expect(User::Create.(name: 'Joe')).to have_succeed_with(:created).and_value(an_i
 expect(User::Create.(name: nil)).to have_failed_with(:invalid_attributes)
 
 expect(User::Create.(name: nil)).to have_failed_with(:invalid_attributes).and_error({ name: ["can't be blank"] })
+
+expect(User::Create.(name: nil)).to have_failed_with(:invalid_attributes).and_error(a_hash_including(name: ["can't be blank"]))
 ```
 
 ## API Docs

--- a/lib/f_service/rspec/support/matchers/result.rb
+++ b/lib/f_service/rspec/support/matchers/result.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define :have_failed_with do |*expected_types|
   match do |actual|
     matched = actual.is_a?(FService::Result::Failure) && actual.types == expected_types
 
-    matched &&= actual.error == @expected_error if defined?(@expected_error)
+    matched &&= values_match?(@expected_error, actual.error) if defined?(@expected_error)
 
     matched
   end


### PR DESCRIPTION
as and_value matcher on success, and_error, now allow to pass a matcher instead a value to be compared using equality:

Ex:

Before:

```rb
expect(User::Create.(username: 'bruno', email: 'invalid@'))
  .to have_failed_with(:invalid_user)
  .and_error(?) # very hard to compare without mocking
```

After:

```rb
expect(User::Create.(username: 'bruno', email: 'invalid@'))
  .to have_failed_with(:invalid_user)
  .and_error(be_a(User))

# Or

expect(User::Create.(username: 'bruno', email: 'invalid@'))
  .to have_failed_with(:invalid_user)
  .and_error(have_attributes(email: 'invalid@'))
```