### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ### Changed -->
 <!-- ### Removed -->
 ---
+
+## 0.3.0
 ### Added
  - Drop Support to Ruby 2.6 and 2.7
  - Add Support to Ruby 3.2 and 3.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    f_service (0.3.0)
+    f_service (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/f_service/version.rb
+++ b/lib/f_service/version.rb
@@ -2,5 +2,5 @@
 
 module FService
   # Current version of the gem
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
 - Drop Support to Ruby 2.6 and 2.7
 - Add Support to Ruby 3.2 and 3.3
 - Changed and_error to use a matcher instead of equality comparation #51