### PR TITLE
Remove deprectated methods Failure#then and Success#then

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ### Added -->
 <!-- ### Changed -->
 <!-- ### Removed -->
+### Removed
+ - Deprecated method Failure#then
+ - Deprecated method Success#then
 ---
 
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ### Changed -->
 <!-- ### Removed -->
 ### Removed
- - Deprecated method Failure#then
- - Deprecated method Success#then
+ - Deprecated method Failure#then #56
+ - Deprecated method Success#then #56
 ---
 
 ## 0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,4 +117,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.32
+   2.3.5

--- a/lib/f_service/result/failure.rb
+++ b/lib/f_service/result/failure.rb
@@ -110,12 +110,6 @@ module FService
         self
       end
 
-      # See #and_then
-      def then
-        FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#and_then', from: caller[0])
-        and_then
-      end
-
       # Outputs a string representation of the object
       #
       #

--- a/lib/f_service/result/success.rb
+++ b/lib/f_service/result/success.rb
@@ -83,13 +83,6 @@ module FService
         yield(*to_ary)
       end
 
-      # See #and_then
-      def then(&block)
-        FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#and_then', from: caller[0])
-
-        and_then(&block)
-      end
-
       # Returns itself to the given block.
       # Use this to chain multiple actions or service calls (only valid when they return a Result).
       # It works just like the `.and_then` method, but only runs if service is a Failure.

--- a/spec/f_service/result/failure_spec.rb
+++ b/spec/f_service/result/failure_spec.rb
@@ -178,26 +178,6 @@ RSpec.describe FService::Result::Failure do
     end
   end
 
-  describe '#then' do
-    subject(:failure) { described_class.new('Pax', :ok) }
-
-    before { allow(FService).to receive(:deprecate!) }
-
-    context 'when a block is given' do
-      it 'returns itself', :aggregate_failures do
-        expect(failure.then { 'an error happened' }).to eq(failure)
-        expect(FService).to have_received(:deprecate!)
-      end
-    end
-
-    context 'when a block is passed as argument' do
-      it 'does not yields the block', :aggregate_failures do
-        expect { |block| failure.then(&block) }.not_to yield_control
-        expect(FService).to have_received(:deprecate!)
-      end
-    end
-  end
-
   describe '#to_s' do
     subject(:failure) { described_class.new('Whoops!') }
 

--- a/spec/f_service/result/success_spec.rb
+++ b/spec/f_service/result/success_spec.rb
@@ -170,28 +170,6 @@ RSpec.describe FService::Result::Success do
     end
   end
 
-  describe '#then' do
-    subject(:success) { described_class.new('Pax', [:ok]) }
-
-    before { allow(FService).to receive(:deprecate!) }
-
-    context 'when a block is given' do
-      it 'returns the given block result', :aggregate_failures do
-        expect(success.then { |value| "Hello, #{value}!" }).to eq('Hello, Pax!')
-        expect(FService).to have_received(:deprecate!)
-      end
-    end
-
-    context 'when a block is passed as argument' do
-      it 'returns the given block argument', :aggregate_failures do
-        block = ->(value, _type) { "Hello, #{value}!" }
-
-        expect(success.then(&block)).to eq('Hello, Pax!')
-        expect(FService).to have_received(:deprecate!)
-      end
-    end
-  end
-
   describe '#or_else' do
     subject(:success) { described_class.new('Pax', [:ok]) }
 


### PR DESCRIPTION
This PR Finishes the migration started by this issue https://github.com/Fretadao/f_service/issues/23
Since the version [v0.2.0](https://github.com/Fretadao/f_service/releases/tag/v0.2.0) we already use and_then instead.