### PR TITLE
chore: clean up gem packaging and development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,10 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'ostruct' # Required by rake on Ruby 4.0+ (no longer a default gem)
+  # Left the stdlib in Ruby 4.0 and are no longer default gems. Until now they
+  # reached the lockfile as transitive dependencies of solargraph.
+  gem 'benchmark' # Required by rubocop
+  gem 'ostruct' # Required by rake
   gem 'pry'
   gem 'pry-nav'
   gem 'rake', '~> 13.4'
@@ -18,8 +21,8 @@ group :docs do
   gem 'yard'
 end
 
-group :optional do
-  gem 'solargraph'
+group :development do
+  gem 'ruby-lsp', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,29 +7,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    backport (1.2.0)
-    benchmark (0.3.0)
+    benchmark (0.5.0)
     coderay (1.1.3)
     diff-lcs (1.3)
     docile (1.3.5)
-    e2mmap (0.1.0)
-    jaro_winkler (1.5.6)
     json (2.7.1)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
+    logger (1.7.0)
     method_source (1.0.0)
-    mini_portile2 (2.8.9)
-    nokogiri (1.18.10)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    prism (1.9.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -38,9 +29,11 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.1.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
     regexp_parser (2.9.0)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.3.9)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -76,6 +69,10 @@ GEM
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+    ruby-lsp (0.26.10)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
     ruby-progressbar (1.13.0)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -83,22 +80,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    solargraph (0.41.2)
-      backport (~> 1.1)
-      benchmark
-      bundler (>= 1.17.2)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      reverse_markdown (>= 1.0.5, < 3)
-      rubocop (>= 0.52)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
-    thor (1.3.0)
-    tilt (2.3.0)
+    tsort (0.2.0)
     unicode-display_width (2.5.0)
     yard (0.9.36)
 
@@ -106,6 +88,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  benchmark
   f_service!
   ostruct
   pry
@@ -114,8 +97,8 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 1.60.2)
   rubocop-rspec
+  ruby-lsp
   simplecov
-  solargraph
   yard
 
 BUNDLED WITH

--- a/f_service.gemspec
+++ b/f_service.gemspec
@@ -26,10 +26,20 @@ Gem::Specification.new do |spec|
   spec.metadata['documentation_uri'] = 'https://www.rubydoc.info/gems/f_service'
   spec.metadata['changelog_uri'] = 'https://github.com/Fretadao/f_service/blob/master/CHANGELOG.md'
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  # Ship only what a consumer of the gem needs: the library, the docs and the
+  # licence. Everything else tracked in the repository is development tooling and
+  # was being packaged until now — CI workflows, git hooks, the Gemfile, and so on.
+  development_only = %r{
+    ^(bin|test|spec|features)/    # console/setup scripts and test suites
+    | ^\.git                      # .gitignore, .github/, .githooks/
+    | ^\.rubocop                  # linter configuration
+    | ^(Gemfile|Rakefile)         # development entrypoints
+    | ^CONTRIBUTING               # contributor documentation
+    | release-please              # release automation configuration
+  }x
+
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").grep_v(development_only)
   end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
## What changed

Two cleanups on what actually gets installed, split out from the README work so each diff stays readable.

**`solargraph` → `ruby-lsp`.** The team moved to ruby-lsp, and this was the only lib in `libs/` still declaring solargraph — pinned at **0.41.2, from June 2021**, against 0.60.3 current. It was also a language server living in a shared Gemfile, which nothing else here does. ruby-lsp goes into the `development` group, matching `99app-client`.

That drops **12 gems** from the lockfile (46 → 39), including the abandoned `e2mmap` and `jaro_winkler`, and — notably — **`nokogiri` and `thor`**, which only reached us through solargraph's `reverse_markdown`.

**Stop packaging development files.** `git ls-files` only rejected `test|spec|features`, so the published gem carried the CI workflows, `.gitignore`, `.rubocop.yml`, `Gemfile`, `Gemfile.lock`, `Rakefile` and `bin/` — confirmed by unpacking 0.3.1 from RubyGems. The release automation merged in #58 had just added the git hooks, the PR template, `CONTRIBUTING.md` and the release-please config to that list.

The package goes from **26 files to 18**: `lib/`, README, CHANGELOG, LICENSE, the logo and the gemspec.

## Why this touches the Dependabot failures

`bundler` Dependabot runs have been failing on this repo since **July 2025** — worth stating up front that this is *not* a regression from #58, which only changed where the config file lives:

| Date | Run | Result |
|---|---|---|
| 2025-07-22 | `for thor` | failure |
| 2026-05-06 / 05-08 | `for yard`, `for nokogiri` ×3 | failure |
| 2026-06-23 / 06-30 | `for nokogiri` ×4, `for yard` | failure |
| 2026-08-19 | `bundler in /.`, `for nokogiri`, `for yard` | failure |

Two of the three gems that keep failing — `nokogiri` and `thor` — leave the lockfile entirely with this PR, so Dependabot stops trying to update them. **This is not a root-cause fix**: I could not read the run log (`GET /actions/runs/:id/logs` returns 403 without credentials), and `yard` is declared directly, so it stays. What it does is remove two thirds of the failing cases and shrink the surface.

Hypotheses already ruled out locally, so nobody repeats them: it is not bundler 4 in the lockfile (bundler 2.7.2 resolves it fine), not missing `registries`/`insecure-external-code-execution` (this gem has no private git dependency), and not a resolution conflict (`bundle update nokogiri` succeeds).

## A latent break this exposed

`benchmark` also left the stdlib in Ruby 4.0, and rubocop needs it. It was in the lockfile **only as a solargraph dependency** — so the Ruby 4.0 job added in #58 was passing by accident. Removing solargraph broke rubocop immediately on 4.0.1, which is how it surfaced. `benchmark` is now declared next to `ostruct`, with a comment saying why both are there.

## Type of change

- [x] `chore` / `ci` / `docs` / `test` / `style` — maintenance *(no release)*

## Checklist

- [x] The **PR title** is a valid Conventional Commit.
- [x] `bundle exec rake` passes on Ruby 4.0.1 and 3.4.2 (94 examples, 0 failures on both).
- [x] `bundle exec rubocop --parallel` clean on both (22 files, no offenses).
- [x] `gem build` succeeds, and the built package was inspected file by file — `lib/` complete (13 files), README and CHANGELOG present, nothing from `.github/`.
- [x] The `CHANGELOG.md` was not edited by hand; release-please owns it.

## Not in scope

`gem build` emits a pre-existing warning: `homepage_uri` and `source_code_uri` point at the same URL, so RubyGems shows only the first. One line to fix, but unrelated to this PR — say the word and it can ride along.

Tracked internally as CU-86ak2yp3d. Next up: the README rewrite, then the `feat!:` that cuts 0.4.0.
