### PR TITLE
docs: modernize the README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ You can optionally specify a list of types which represents that result and a va
 class User::Create < FService::Base
   # ...
   def run
-    return Failure(:no_name, :invalid_attribute) if @name.nil?
+    return Failure(:invalid_name, data: { name: ["can't be blank"] }) if @name.nil?
 
     user = UserRepository.create(name: @name)
+
     if user.save
-      Success(:success, :created, data: user)
+      Success(:created, data: user)
     else
       Failure(:creation_failed, data: user.errors)
     end
@@ -82,6 +83,11 @@ end
 ```
 
 > Remember, you **have** to return an `FService::Result` at the end of your services.
+
+> Always give your results a type. It says what happened, not just whether it worked, so
+> callers can branch on the reason and a failure is readable in a log without opening the
+> service. Pass the payload in `data:`, including on failures — otherwise `#error` is `nil`
+> and whoever serializes it has nothing to show.
 
 ### Using your service
 
@@ -117,7 +123,7 @@ class UsersController < BaseController
 end
 ```
 
-> Note that you're not limited to using services inside controllers. They're just PORO's (Play Old Ruby Objects), so you can use in controllers, models, etc. (even other services!).
+> Note that you're not limited to using services inside controllers. They're just PORO's (Plain Old Ruby Objects), so you can use in controllers, models, etc. (even other services!).
 
 ### Pattern matching
 
@@ -126,70 +132,65 @@ The code above could be rewritten using the `#on_success` and `#on_failure` hook
 ```ruby
 class UsersController < BaseController
   def create
-    User::Create.(user_params)
-                .on_success { |value| return json_success(value) }
-                .on_failure { |error| return json_error(error) }
-  end
-end
-```
-
-Or else it is possible to specify an unhandled option to ensure that the callback will process that message anyway the
-error.
-
-```ruby
-class UsersController < BaseController
-  def create
-    User::Create.(user_params)
-                .on_success(unhandled: true) { |value| return json_success(value) }
-                .on_failure(unhandled: true) { |error| return json_error(error) }
-  end
-end
-```
-
-```ruby
-class UsersController < BaseController
-  def create
-    User::Create.(user_params)
-                .on_success { |value| return json_success(value) }
-                .on_failure { |error| return json_error(error) }
+    User::Create
+      .call(user_params)
+      .on_success { |user| return json_success(user) }
+      .on_failure { |errors| return json_error(errors) }
   end
 end
 ```
 
 > You can ignore any of the callbacks, if you want to.
 
+Once you start matching specific types (below), a result whose type none of the hooks
+mention falls through untouched. Pass `unhandled: true` to run a callback for exactly those
+leftovers:
+
+```ruby
+class UsersController < BaseController
+  def create
+    User::Create
+      .call(user_params)
+      .on_success(:created) { |user| return json_success(user) }
+      .on_failure(unhandled: true) { |errors| return json_error(errors) }
+  end
+end
+```
+
 Going further, you can match the Result type, in case you want to handle them differently:
 
 ```ruby
 class UsersController < BaseController
   def create
-    User::Create.(user_params)
-                .on_success(:user_created) { |value| return json_success(value) }
-                .on_success(:user_already_exists) { |value| return json_success(value) }
-                .on_failure(:invalid_data) { |error| return json_error(error) }
-                .on_failure(:critical_error) do |error|
-                  MyLogger.report_failure(error)
+    User::Create
+      .call(user_params)
+      .on_success(:created) { |user| return json_success(user) }
+      .on_failure(:invalid_name) { |errors| return json_error(errors) }
+      .on_failure(:creation_failed) do |errors|
+        MyLogger.report_failure(errors)
 
-                  return json_error(error)
-                end
+        return json_error(errors)
+      end
   end
 end
 ```
 
 It's possible to provide multiple types to the hooks too. If the result type matches any of the given types,
-the hook will run.
+the hook will run. Say the service also answers `Success(:already_exists, data: user)` when the
+name is taken — both outcomes are fine for the caller:
 
 ```ruby
 class UsersController < BaseController
   def create
-    User::Create.(user_params)
-                .on_success(:user_created, :user_already_exists) { |value| return json_success(value) }
-                .on_failure(:invalid_data) { |error| return json_error(error) }
-                .on_failure(:critical_error) do |error|
-                  MyLogger.report_failure(error)
+    User::Create
+      .call(user_params)
+      .on_success(:created, :already_exists) { |user| return json_success(user) }
+      .on_failure(:invalid_name) { |errors| return json_error(errors) }
+      .on_failure(:creation_failed) do |errors|
+        MyLogger.report_failure(errors)
 
-                  return json_error(error)
-                end
+        return json_error(errors)
+      end
   end
 end
 ```
@@ -211,9 +212,10 @@ If some step fails, it will short circuit the call chain.
 ```ruby
 class UsersController < BaseController
   def create
-    result = User::Create.(user_params)
-                         .and_then { |user| User::Login.(user) }
-                         .and_then { |user| User::SendWelcomeEmail.(user) }
+    result = User::Create
+      .call(user_params)
+      .and_then { |user| User::Login.(user) }
+      .and_then { |user| User::SendWelcomeEmail.(user) }
 
     if result.successful?
       json_success(result.value)
@@ -229,17 +231,23 @@ You can use the `.to_proc` method on FService::Base to avoid explicit inputs whe
 ```ruby
 class UsersController < BaseController
   def create
-    result = User::Create.(user_params)
-                         .and_then(&User::Login)
-                         .and_then(&User::SendWelcomeEmail)
+    result = User::Create
+      .call(user_params)
+      .and_then(&User::Login)
+      .and_then(&User::SendWelcomeEmail)
     # ...
   end
 end
 ```
 
+> **Coming from 0.2.x?** `Success#then` and `Failure#then` were deprecated in 0.3.0 and
+> removed in 0.4.0. Use `#and_then`, which has always been their alias and behaves
+> identically. Note that `#then` also exists on every Ruby object since 2.6, so a leftover
+> call does not raise — it silently yields the Result itself instead of its value.
+
 ### `Check` and `Try`
 
-You can use `Check` to converts a boolean to a Result, truthy values map to `Success`, and falsey values map to `Failures`:
+You can use `Check` to convert a boolean into a Result: truthy values map to `Success`, falsey values to `Failure`.
 
 ```ruby
 Check(:math_works) { 1 < 2 }
@@ -253,73 +261,117 @@ Check(:math_works) { 1 > 2 }
 using the parameter `catch`.
 
 ```ruby
-class IHateEvenNumbers < FService::Base
+class Number::DrawOdd < FService::Base
   def run
-    Try(:rand_int) do
-      n = rand(1..10)
-      raise "Yuck! It's a #{n}" if n.even?
+    Try(:drawn_number) do
+      drawn_number = rand(1..10)
+      raise "Yuck! It's a #{drawn_number}" if drawn_number.even?
 
-      n
+      drawn_number
     end
   end
 end
 
-IHateEvenNumbers.call
-# => #<Success @value=9, @types=[:rand_int]>
+Number::DrawOdd.call
+# => #<Success @value=9, @types=[:drawn_number]>
 
-IHateEvenNumbers.call
-# => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @types=[:rand_int]>
+Number::DrawOdd.call
+# => #<Failure @error=#<RuntimeError: Yuck! It's a 4>, @types=[:drawn_number]>
 ```
 
 ## Testing
 
-We provide some helpers and matchers to make ease to test code envolving Fservice services.
+We provide helpers and matchers to make it easier to test code involving FService services.
 
-To make available in the system, in the file 'spec/spec_helper.rb' or 'spec/rails_helper.rb'
+To make them available, add the following require to `spec/spec_helper.rb` or
+`spec/rails_helper.rb`:
 
-add the folowing require:
-
-```rb
+```ruby
 require 'f_service/rspec'
 ```
 
 ### Mocking a result
 
-```rb
-mock_service(Uer::Create)
-# => Mocks a successful result with all values nil
+`mock_service` stubs the service's `#call` and returns the Result you describe. It is a stub,
+not a message expectation: it does not assert that the service was called, so add your own
+`expect(...).to have_received(:call)` when that is the point of the test.
 
-mock_service(Uer::Create, result: :success)
-# => Mocks a successful result with all values nil
+```ruby
+mock_service(User::Create)
+# => stubs a successful result, with no types and a nil value
 
-mock_service(Uer::Create, result: :success, types: [:created, :success])
-# => Mocks a successful result with type created
+mock_service(User::Create, result: :success, types: [:created])
+# => stubs a Success typed :created
 
-mock_service(Uer::Create, result: :success, types: :created, value: instance_spy(User))
-# => Mocks a successful result with type created and a value
+mock_service(User::Create, result: :success, types: [:created], value: instance_spy(User))
+# => stubs a Success typed :created carrying a value
 
-mock_service(Uer::Create, result: :failure)
-# => Mocs a failure with all nil values
+mock_service(User::Create, result: :failure, types: [:invalid_name])
+# => stubs a Failure typed :invalid_name, with a nil error
 
-mock_service(User::Create, result: :failure, types: [:unprocessable_entity, :client_error])
-# => Mocs a failure with a failure type
+mock_service(
+  User::Create,
+  result: :failure,
+  types: [:invalid_name],
+  value: { name: ["can't be blank"] }
+)
+# => stubs a Failure typed :invalid_name carrying an error
+```
 
-mock_service(User::Create, result: :failure, types: [:unprocessable_entity, :client_error], value: { name: ["can't be blank"] })
-# => Mocs a failure with a failure type and an error value
+> `value:` fills `#value` on a Success and `#error` on a Failure — it is the payload either
+> way. `types:` also accepts a bare symbol, but an array reads consistently. There is an older
+> `type:` (singular) argument: it still works and prints a deprecation warning pointing at
+> `types:`.
+
+Need the Result object itself rather than a stub — to pass it around in a unit test, say?
+`f_service_result` builds one:
+
+```ruby
+result = f_service_result(:failure, { name: ["can't be blank"] }, [:invalid_name])
+# => #<Failure @error={name: ["can't be blank"]}, @types=[:invalid_name]>
 ```
 
 ### Matching a result
 
-```rb
+```ruby
 expect(User::Create.(name: 'Joe')).to have_succeed_with(:created)
 
 expect(User::Create.(name: 'Joe')).to have_succeed_with(:created).and_value(an_instance_of(User))
 
-expect(User::Create.(name: nil)).to have_failed_with(:invalid_attributes)
+expect(User::Create.(name: nil)).to have_failed_with(:invalid_name)
 
-expect(User::Create.(name: nil)).to have_failed_with(:invalid_attributes).and_error({ name: ["can't be blank"] })
+expect(User::Create.(name: nil))
+  .to have_failed_with(:invalid_name).and_error({ name: ["can't be blank"] })
 
-expect(User::Create.(name: nil)).to have_failed_with(:invalid_attributes).and_error(a_hash_including(name: ["can't be blank"]))
+expect(User::Create.(name: nil))
+  .to have_failed_with(:invalid_name).and_error(a_hash_including(name: ["can't be blank"]))
+```
+
+> The matchers compare the type list for **equality**, not inclusion. A service answering
+> `Success(:created, :persisted)` is matched by `have_succeed_with(:created, :persisted)` —
+> `have_succeed_with(:created)` alone fails. Name every type the result carries.
+
+Putting it together, a spec for the service built above:
+
+```ruby
+RSpec.describe User::Create do
+  subject(:create_user) { described_class.call(name: name) }
+
+  context 'when the name is given' do
+    let(:name) { 'Joe' }
+
+    it { is_expected.to have_succeed_with(:created).and_value(an_instance_of(User)) }
+  end
+
+  context 'when the name is missing' do
+    let(:name) { nil }
+
+    it 'fails naming the offending attribute' do
+      expect(create_user)
+        .to have_failed_with(:invalid_name).and_error(a_hash_including(:name))
+    end
+  end
+end
 ```
 
 ## API Docs


### PR DESCRIPTION
## What changed

Rewrites the README examples. They had drifted from the style the team writes today — but the important part is that several of them **did not work**.

## The examples could not pass

The matchers compare the type list for **equality**, not inclusion. The service example answered `Success(:success, :created, data: user)` while the spec example expected `have_succeed_with(:created)`. Anyone copying both got a red spec.

I ran both versions to be sure rather than assume. The old pair fails on both examples:

```
expected success's types '[:success, :created]' to be equal '[:created]'
expected failure's types '[:no_name, :invalid_attribute]' to be equal '[:invalid_attributes]'
```

The whole README now speaks one vocabulary — `:created`, `:invalid_name`, `:creation_failed` — emitted by the service, matched by the hooks, expected by the specs. The new example spec runs green against the new example service (2 examples, 0 failures).

## Other things that were broken

- **`Uer::Create` on five lines** — a typo for `User`. Copy-pasting raises `NameError`.
- **`Success(:success, :created, …)` contradicted the README itself.** Two sections below, "Type precedence" documents matching from specific to generic — and `:success` sat in front, swallowing everything before `:created` got a chance.
- **`Failure(:no_name, :invalid_attribute)` passed no `data:`**, so `#error` was `nil` in the very controller examples that serialize it.
- **A pattern matching block appeared twice**, byte for byte, the second time with no text introducing it.
- **No migration note for `then` → `and_then`.** The removal ships in 0.4.0 and was documented nowhere — not the README, not the CHANGELOG. Worth stating explicitly, because `Object#then` has existed since Ruby 2.6, so a leftover call **does not raise**: it silently yields the Result instead of its value. Confirmed in a console:

  ```
  result.and_then { |value| ... }  # => "payload"
  result.then { |yielded| ... }    # => FService::Result::Success
  ```

## Style

Following `rubocop-fretadao` and `rubocop-vicenzo`:

- **Chains** used "boxcar" indentation aligned to the receiver — the first `# bad` example of `Vicenzo/Layout/MultilineMethodCallLineBreaks`, and fragile: renaming the class reindents the whole block. Now one call per line, indented by two.
- **Block variables say what they hold** — `|user|`, `|errors|` instead of `|value|`, `|error|`. `n` in the `Try` example became `drawn_number`.
- Two code lines were over **120 columns**; both broken up.
- `IHateEvenNumbers` → `Number::DrawOdd`.
- The three test blocks used ` ```rb ` while the other fifteen used ` ```ruby `.

**`User::Create` stays as is.** `Fretadao/Naming/ServiceClassSuffix` is scoped to `app/services/` with `ApplicationService` inheritance, and `config/style.yml` sets `Style/ClassAndModuleChildren: compact` — so `class User::Create` already *is* the house style. The gem also does not gain `rubocop-fretadao` as a dependency; the examples follow the convention because they are the maintainer's teaching material, not because the gem starts imposing style on its users.

## Gaps filled

- **A structured spec example.** Every testing snippet was a loose one-liner, so nothing showed where `mock_service` goes or how to organise contexts by result type.
- **`mock_service` is a stub, not a message expectation** — it stubs `#call` and never asserted that the service was called. Now said out loud.
- `value:` is documented as the payload for *both* Success and Failure, `types:` consistently as an array, and `f_service_result` gets a mention — it was a public helper documented nowhere. Also notes the deprecated singular `type:`.
- The matchers' equality-not-inclusion behaviour is stated where it bites.
- Prose typos: `Mocs` ×3, `envolving`, `folowing`, "Play Old Ruby Objects" (it is *Plain*), "use `Check` to converts", and a sentence about `unhandled:` that trailed off mid-thought — replaced with an explanation of what the option actually does.

## Type of change

- [x] `chore` / `ci` / `docs` / `test` / `style` — maintenance *(no release)*

## Checklist

- [x] The **PR title** is a valid Conventional Commit.
- [x] `bundle exec rake` passes (94 examples) and `rubocop --parallel` is clean (22 files).
- [x] The README's spec example was **executed** against the README's service example — 2 examples, 0 failures.
- [x] All 12 complete code blocks were extracted and linted against the team's style guide (`--config rubocop-fretadao/config/style.yml`, checking `MultilineMethodCallLineBreaks`, `MultilineMethodCallParentheses`, `ResultWithoutType`, `LineLength`, `MultilineMethodCallIndentation`) — no offenses.
- [x] No code line exceeds 120 columns.
- [x] The `CHANGELOG.md` was not edited by hand; release-please owns it.

Tracked internally as CU-86ak2yp3d. Next and last: `feat!: remove deprecated Failure#then and Success#then`, whose title cuts **0.4.0** — landing after this one so the release ships with the new README inside the package.
