### PR TITLE
feat!: remove deprecated Failure#then, Success#then and the 0.2.0 leftovers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,55 @@ Pull requests are squash-merged, so **the PR title becomes the commit message**
 release-please reads. Get the title right even when the individual commits are
 messy — a workflow checks it on every pull request.
 
+## Deprecating something
+
+This gem is public, so nothing user-facing is removed without warning first. The cycle is
+deprecate, ship at least one release with the warning, then remove in a release that says so.
+
+**1. Mark it.** Keep the method working and warn from inside it. `FService.deprecate!` exists
+for exactly this and prints a message pointing at the replacement, including the caller:
+
+```ruby
+# @deprecated Use {#Success} instead.
+def success(data = nil)
+  FService.deprecate!(
+    name: "#{self.class}##{__method__}",
+    alternative: '#Success',
+    from: caller[0]
+  )
+
+  Result::Success.new(data)
+end
+```
+
+For an argument rather than a whole method, use `FService.deprecate_argument_name`:
+
+```ruby
+FService.deprecate_argument_name(
+  name: 'mock_service',
+  argument_name: :type,
+  alternative: 'mock_service(..., types: [:created])',
+  from: caller[0]
+)
+```
+
+Add the `@deprecated` YARD tag too — it shows up in the API docs on RubyDoc.
+
+**2. Ship it.** A commit that only deprecates is a `feat:` (new warning, nothing breaks) and
+goes out in a normal minor release. Say in the commit body what replaces it.
+
+**3. Remove it, later.** In a separate release, drop the method and its specs, and use
+`feat!:` with a `BREAKING CHANGE:` footer so release-please bumps accordingly and writes the
+`⚠ BREAKING CHANGES` section. Grep the README for the removed name — documentation that still
+promises the old API is worse than no documentation.
+
+> Do not skip the middle step. `#success`, `#failure` and `#result` were deprecated in 0.2.0
+> with a note saying they would go "on the next release", and were only removed in 0.4.0 —
+> three releases later. Better to over-warn than to break someone quietly.
+
+The two `FService.deprecate*` helpers sit unused between deprecations. That is expected: they
+are the tooling for this process, not dead code, and the next deprecation picks them up again.
+
 ## Releasing (release-please)
 
 Releases are automated with [release-please](https://github.com/googleapis/release-please);

--- a/README.md
+++ b/README.md
@@ -319,9 +319,8 @@ mock_service(
 ```
 
 > `value:` fills `#value` on a Success and `#error` on a Failure — it is the payload either
-> way. `types:` also accepts a bare symbol, but an array reads consistently. There is an older
-> `type:` (singular) argument: it still works and prints a deprecation warning pointing at
-> `types:`.
+> way. `types:` also accepts a bare symbol, but an array reads consistently. The deprecated
+> singular `type:` argument was removed in 0.4.0.
 
 Need the Result object itself rather than a stub — to pass it around in a unit test, say?
 `f_service_result` builds one:

--- a/lib/f_service/base.rb
+++ b/lib/f_service/base.rb
@@ -78,36 +78,6 @@ module FService
       raise NotImplementedError, 'Services must implement #run'
     end
 
-    # Returns a successful operation.
-    # You'll probably want to return this inside {#run}.
-    #
-    #
-    # @example
-    #   class User::ValidateAge < FService::Base
-    #     def initialize(age:)
-    #       @age = age
-    #     end
-    #
-    #     def run
-    #       return failure(status: 'No age given!', data: @age) if age.blank?
-    #       return failure(status: 'Too young!', data: @age) if age < 18
-    #
-    #       success(status: 'Valid age.', data: @age)
-    #     end
-    #   end
-    #
-    # @deprecated Use {#Success} instead.
-    # @return [Result::Success] a successful operation
-    def success(data = nil)
-      FService.deprecate!(
-        name: "#{self.class}##{__method__}",
-        alternative: '#Success',
-        from: caller[0]
-      )
-
-      Result::Success.new(data)
-    end
-
     # Returns a successful result.
     # You can optionally specify a list of types and a value for your result.
     # You'll probably want to return this inside {#run}.
@@ -228,68 +198,6 @@ module FService
       Success(*types, data: res)
     rescue *catch => e
       Failure(*types, data: e)
-    end
-
-    # Returns a failed operation.
-    # You'll probably want to return this inside {#run}.
-    # @example
-    #   class User::ValidateAge < FService::Base
-    #     def initialize(age:)
-    #       @age = age
-    #     end
-    #
-    #     def run
-    #       return failure(status: 'No age given!', data: @age) if age.blank?
-    #       return failure(status: 'Too young!', data: @age) if age < 18
-    #
-    #       success(status: 'Valid age.', data: @age)
-    #     end
-    #   end
-    #
-    # @deprecated Use {#Failure} instead.
-    # @return [Result::Failure] a failed operation
-    def failure(data = nil)
-      FService.deprecate!(
-        name: "#{self.class}##{__method__}",
-        alternative: '#Failure',
-        from: caller[0]
-      )
-
-      Result::Failure.new(data)
-    end
-
-    # Return either {Result::Failure Success} or {Result::Failure Failure}
-    # given the condition.
-    #
-    # @example
-    #   class YearIsLeap < FService::Base
-    #     def initialize(year:)
-    #       @year = year
-    #     end
-    #
-    #     def run
-    #       return failure(status: 'No year given!', data: @year) if @year.nil?
-    #
-    #       result(leap?, @year)
-    #     end
-    #
-    #     private
-    #
-    #     def leap?
-    #       ((@year % 4).zero? && @year % 100 != 0) || (@year % 400).zero?
-    #     end
-    #   end
-    #
-    # @deprecated Use {#Check} instead.
-    # @return [Result::Success, Result::Failure]
-    def result(condition, data = nil)
-      FService.deprecate!(
-        name: "#{self.class}##{__method__}",
-        alternative: '#Check',
-        from: caller[0]
-      )
-
-      condition ? success(data) : failure(data)
     end
   end
 end

--- a/lib/f_service/result/base.rb
+++ b/lib/f_service/result/base.rb
@@ -22,13 +22,6 @@ module FService
         @matching_types = []
       end
 
-      # Implements old attribute type. Its deprecated in favor of using types.
-      def type
-        FService.deprecate!(name: "#{self.class}##{__method__}", alternative: '#types', from: caller[0])
-
-        types.size == 1 ? types.first : Array(@matching_types).first
-      end
-
       # This hook runs if the result is successful.
       # Can receive one or more types to be checked before running the given block.
       #

--- a/lib/f_service/rspec/support/helpers/result.rb
+++ b/lib/f_service/rspec/support/helpers/result.rb
@@ -12,17 +12,8 @@ module FServiceResultHelpers
   end
 
   # Mock a Fservice service call returning a result.
-  def mock_service(service, result: :success, value: nil, type: :not_passed, types: [])
-    result_types = Array(types)
-
-    if type != :not_passed
-      alternative = "mock_service(..., types: [#{type.inspect}])"
-      name = 'mock_service'
-      FService.deprecate_argument_name(name: name, argument_name: :type, alternative: alternative, from: caller[0])
-      result_types = Array(type)
-    end
-
-    service_result = f_service_result(result, value, result_types)
+  def mock_service(service, result: :success, value: nil, types: [])
+    service_result = f_service_result(result, value, Array(types))
     allow(service).to receive(:call).and_return(service_result)
   end
 end

--- a/spec/f_service/base_spec.rb
+++ b/spec/f_service/base_spec.rb
@@ -3,23 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe FService::Base do
-  describe '#success' do
-    subject(:response) { described_class.new.success('yay!') }
-
-    it { expect(response.value).to eq('yay!') }
-  end
-
   describe '#Success' do
     subject(:response) { described_class.new.Success(:ok, data: 'yay!') }
 
     it { expect(response.types).to contain_exactly(:ok) }
     it { expect(response.value).to eq('yay!') }
-  end
-
-  describe '#failure' do
-    subject(:response) { described_class.new.failure('Whoops!') }
-
-    it { expect(response.error).to eq('Whoops!') }
   end
 
   describe '#Failure' do
@@ -93,22 +81,6 @@ RSpec.describe FService::Base do
     end
   end
 
-  describe '#result' do
-    subject(:response) { described_class.new.result(condition) }
-
-    context 'when condition is true' do
-      let(:condition) { 1 < 2 }
-
-      it { expect(response).to be_successful }
-    end
-
-    context 'when condition is false' do
-      let(:condition) { 1 > 2 }
-
-      it { expect(response).to be_failed }
-    end
-  end
-
   describe '.to_proc' do
     let(:double_number) do
       Class.new(described_class) do
@@ -134,7 +106,7 @@ RSpec.describe FService::Base do
     let(:test_service) do
       Class.new(described_class) do
         def run
-          success('This service is alright')
+          Success(:ok, data: 'This service is alright')
         end
       end
     end

--- a/spec/f_service/result/base_spec.rb
+++ b/spec/f_service/result/base_spec.rb
@@ -16,41 +16,4 @@ RSpec.describe FService::Result::Base do
       end
     end
   end
-
-  describe '#type' do
-    before { allow(FService).to receive(:deprecate!) }
-
-    context 'when types has just one type' do
-      let(:test_class) do
-        Class.new(described_class) do
-          def initialize
-            super
-            @types = %i[success]
-          end
-        end
-      end
-
-      it 'deprecates this method', :aggregate_failures do
-        expect(test_class.new.type).to eq(:success)
-        expect(FService).to have_received(:deprecate!)
-      end
-    end
-
-    context 'when types has multiple values' do
-      let(:test_class) do
-        Class.new(described_class) do
-          def initialize
-            super
-            @types = %i[ok success http_response]
-            @matching_types = %i[ok success]
-          end
-        end
-      end
-
-      it 'deprecates this method', :aggregate_failures do
-        expect(test_class.new.type).to eq(:ok)
-        expect(FService).to have_received(:deprecate!)
-      end
-    end
-  end
 end


### PR DESCRIPTION
## What changed

Clears out **every** deprecated API the gem was carrying. This is the PR whose title cuts **0.4.0**.

`Failure#then` and `Success#then` were removed in #56 and **never released** — the last release is 0.3.1, from July 2024. That commit predates the Conventional Commits adopted in #58, so release-please cannot see it. Without a PR declaring the removal, the next `fix:` would ship a removal of public API inside a patch.

The rest had been waiting even longer. The 0.2.0 changelog said `Base#success`, `Base#failure` and `Base#result` *"will be removed on the next release"* — that was **2021**, and they survived 0.3.0 and 0.3.1 untouched.

| Removed | Use instead | Deprecated in |
|---|---|---|
| `Success#then`, `Failure#then` | `#and_then` | 0.3.0 |
| `Base#success` | `#Success` | 0.2.0 |
| `Base#failure` | `#Failure` | 0.2.0 |
| `Base#result` | `#Check` | 0.2.0 |
| `Result#type` | `#types` | 0.3.0 |
| `mock_service(type:)` | `types:` (array) | 0.3.0 |

Two follow-on fixes the removal forced: the `.call` spec was building its test service with `success(...)`, so it moves to `Success(:ok, data: ...)`; and the README claimed the singular `type:` still worked, which stops being true here.

## Why the helpers stay

`FService.deprecate!` and `FService.deprecate_argument_name` now have no callers. They are staying — they are the tooling for this process, not dead code, and the next deprecation picks them up again.

To stop them rotting, `CONTRIBUTING.md` gains a **"Deprecating something"** section: mark the method with a warning using these helpers plus the `@deprecated` YARD tag, ship at least one release with the warning (a `feat:`, since nothing breaks yet), then remove in a later `feat!:` with a `BREAKING CHANGE:` footer — and grep the README, because documentation still promising the old API is worse than none.

It also records the failure mode this PR is cleaning up: three releases of drift between the 0.2.0 promise and the actual removal. Better to over-warn than to break someone quietly.

## Type of change

- [x] `feat` — new capability *(triggers a minor release)*
- [x] breaking change — `!` in the title **and** a `BREAKING CHANGE:` footer

`bump-minor-pre-major` is on, so a breaking change while in `0.x` bumps the **minor**: 0.3.1 → **0.4.0**, not 1.0.0.

## Checklist

- [x] The **PR title** is a valid Conventional Commit and carries the `!`.
- [x] `bundle exec rake` passes on Ruby 4.0.1 and 3.4.2 (88 examples, 0 failures — down from 94, since the specs for the removed methods went with them).
- [x] `bundle exec rubocop --parallel` clean on both (22 files, no offenses).
- [x] The README's spec example still runs green against the README's service example (2 examples, 0 failures).
- [x] No references to the removed API remain in `lib/` or the README.
- [x] The `CHANGELOG.md` was not edited by hand; release-please owns it.

## What to expect after merging

This is the first release the new mechanism cuts end to end:

1. release-please opens `chore(master): release 0.4.0` — **0.4.0**, not 0.3.2 — touching `version.rb`, the manifest, `CHANGELOG.md`, `Gemfile.lock` and the README install snippet, with CI running.
2. The new CHANGELOG section should carry a **`⚠ BREAKING CHANGES`** block listing the removals, sitting above `## 0.3.1`, with the Keep a Changelog preamble untouched at the top.
3. Merging that PR creates tag `v0.4.0` + the GitHub Release, which fires `publish.yml`.

⚠️ **The trusted publisher on RubyGems is the one step never exercised.** If it is not registered yet (repository `Fretadao/f_service`, workflow `publish.yml`, empty environment), the publish fails — recoverable with *Re-run jobs* once it is set, since the tag and Release will already exist.

The package will ship with the rewritten README and without the development files, from #62 and #59.

Tracked internally as CU-86ak2yp3d.
