### PR TITLE
fix: expose FService::VERSION from the entrypoint

### DIFF
--- a/lib/f_service.rb
+++ b/lib/f_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'f_service/base'
+require_relative 'f_service/version'
 
 # A small, monad-based service class
 #

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,14 @@
       "package-name": "f_service",
       "version-file": "lib/f_service/version.rb",
       "extra-files": [
-        { "type": "generic", "path": "README.md" }
+        {
+          "type": "generic",
+          "path": "README.md"
+        },
+        {
+          "type": "generic",
+          "path": "spec/f_service_spec.rb"
+        }
       ]
     }
   }

--- a/spec/f_service_spec.rb
+++ b/spec/f_service_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FService do
+  describe 'version number' do
+    # Kept in sync by release-please: this file is listed in extra-files, and the
+    # marker below tells the generic updater which line to rewrite on release.
+    it { expect(described_class::VERSION).to eq('0.4.0') } # x-release-please-version
+  end
+end


### PR DESCRIPTION
## What changed

One line in the entrypoint. `require 'f_service'` only loaded `f_service/base`, so reaching `FService::VERSION` raised `NameError` unless the caller also required `'f_service/version'` explicitly:

```ruby
require 'f_service'
FService::VERSION  # => NameError: uninitialized constant FService::VERSION
```

Most gems expose the constant from the entrypoint, and this one advertises it nowhere. It surfaced while inspecting the 0.4.0 package right after publishing — and it is **not** a regression: `lib/f_service.rb` is identical on this point in 0.3.1.

Nothing that already worked changes.

## The spec, and release-please keeping it current

`spec/f_service_spec.rb` is the plain assertion from the gem skeleton, against the literal version:

```ruby
it { expect(described_class::VERSION).to eq('0.4.0') } # x-release-please-version
```

The file is listed in `extra-files`, and that trailing marker is what makes it maintainable: the generic updater has an inline mode, so release-please rewrites *that line* on the release PR, right next to `version.rb`. The expectation cannot drift and nobody has to remember it.

Simulated the updater's own regexes against the file to be sure rather than assume — on a 0.4.1 release the line becomes `eq('0.4.1')`.

**Being explicit about what this spec does not do:** it does not guard the require. The Gemfile uses `gemspec`, so Bundler evaluates `f_service.gemspec`, which itself does `require 'f_service/version'` — the constant is defined inside the suite whatever the entrypoint does, and the assertion passes with this fix reverted. What it covers is the constant existing and matching the released version.

Checking the require itself needs a subprocess with `Bundler.with_unbundled_env` (a plain subprocess inherits `RUBYOPT` and Bundler defines the constant again). That is a script rather than an example, so it is not here. Verified by hand:

```
$ ruby -Ilib -e 'require "f_service"; puts FService::VERSION'
0.4.0
```

## Why `fix:` and not `feat:`

Debatable, so stating the reasoning: this only stops a `NameError` on a constant the gem was already shipping, rather than adding capability. A patch (0.4.1) is proportional; a minor would read as if something new arrived. Retitling is a one-word change if you see it the other way — the version follows the title.

## Type of change

- [x] `fix` — bug fix *(triggers a patch release)*

## Checklist

- [x] The **PR title** is a valid Conventional Commit.
- [x] `bundle exec rake` passes (89 examples, 0 failures) and `rubocop --parallel` is clean (23 files).
- [x] `release-please-config.json` is valid JSON, and the inline marker was simulated against the updater's regexes.
- [x] The spec was confirmed to fail when the expected version diverges.
- [x] The `CHANGELOG.md` was not edited by hand; release-please owns it.

Merging this should open a `chore(master): release 0.4.1` PR — the first patch the automation cuts, after a minor and a breaking one. Watch for the spec line being bumped to `eq('0.4.1')` in that PR's diff, alongside `version.rb` and the README snippet.

Tracked internally as CU-86ak2yp3d.
